### PR TITLE
Enable rezisind for "Message" textarea

### DIFF
--- a/src/main/webapp/groups/messages.html
+++ b/src/main/webapp/groups/messages.html
@@ -83,7 +83,7 @@
                                     <!--<h3>New message</h3>-->
                                 <!--</div>-->
                                 <div class="">
-                                    <textarea class="field" style="width: 96%; resize: none;" rows="2" id="postit"
+                                    <textarea class="field" style="width: 96%;" rows="2" id="postit"
                                               placeholder="New message text"></textarea>
                                     <div class="">
                                         <!--<button type="button" data-dismiss="modal" class="btn btn-warning cancel pull-right">-->


### PR DESCRIPTION
Currently there is no way to input big messages (without using external editor). I don't see any point for disabling resize.